### PR TITLE
Fix click on a label wrapping vaadin-input.

### DIFF
--- a/test/index.html
+++ b/test/index.html
@@ -14,7 +14,8 @@
 
     WCT.loadSuites([
       'properties.html',
-      'validate.html'
+      'validate.html',
+      'interaction.html'
     ].reduce(function(suites, suite) {
       return suites.concat([suite, suite + '?wc-shadydom=true']);
     }, []));

--- a/test/interaction.html
+++ b/test/interaction.html
@@ -1,0 +1,53 @@
+<!doctype html>
+
+<head>
+  <meta charset="UTF-8">
+  <title>vaadin-input tests</title>
+
+  <script src="../../web-component-tester/browser.js"></script>
+  <link rel="import" href="../vaadin-input.html">
+  <link rel="import" href="../../iron-form/iron-form.html">
+
+</head>
+
+<body>
+  <test-fixture id="default">
+    <template>
+      <label>
+        <div>
+          <vaadin-input id="vaadinInput"></vaadin-input>
+        </div>
+      </label>
+    </template>
+  </test-fixture>
+
+  <script>
+
+    describe('focus', function() {
+      var label, vaadinInput;
+
+      beforeEach(function(done) {
+        label = fixture('default');
+
+        // wait for the web component to be ready
+        window.setTimeout(function() {
+          vaadinInput = label.querySelector('#vaadinInput');
+          done();
+        }, 1);
+      });
+
+      it('should focus on label click', function() {
+        label.click();
+        expect(vaadinInput.focused).to.be.true;
+      });
+
+      it('should have methods focus and blur', function() {
+        vaadinInput.focus();
+        expect(vaadinInput.focused).to.be.true;
+        vaadinInput.blur();
+        expect(vaadinInput.focused).to.be.false;
+      });
+
+    });
+  </script>
+</body>

--- a/vaadin-input.html
+++ b/vaadin-input.html
@@ -189,6 +189,17 @@ This program is available under Apache License Version 2.0, available at https:/
               type: Boolean,
               reflectToAttribute: true,
               notify: true
+            },
+
+            /**
+             * If true, the element currently has focus.
+             */
+            focused: {
+              type: Boolean,
+              value: false,
+              notify: true,
+              readOnly: true,
+              reflectToAttribute: true
             }
           }
 
@@ -201,8 +212,29 @@ This program is available under Apache License Version 2.0, available at https:/
 
         // Make FF take the focus (#9)
         if (this.autofocus) {
-          this.$.input.focus();
+          this.focus();
         }
+
+        // Figure out whether the element is wrapped in a ´<label>` to take the focus on click.
+        for (var e = this; (e = e.parentElement);) {
+          if (e.localName == 'label') {
+            e.addEventListener('click', this.focus.bind(this));
+            break;
+          }
+        }
+
+        this.$.input.addEventListener('focus', this.focus.bind(this));
+        this.$.input.addEventListener('blur', this.blur.bind(this));
+      }
+
+      focus() {
+        this._setFocused(true);
+        this.$.input.focus();
+      }
+
+      blur() {
+        this._setFocused(false);
+        this.$.input.blur();
       }
 
       _valueChanged(value) {


### PR DESCRIPTION
Fixes #7

Explanation:
- Click on a <label> automatically focus the first <input> in its inner dom.
- It does not focus any non-input element, although it has tabindex attr.
- It does not focus an <input> if it is inside a shadow dom.
- So a simple fix is to transverse the dom up and add click listener to label.

This also adds:
- `focusable` property, `focus()` and `blur()` methods.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-input/13)
<!-- Reviewable:end -->
